### PR TITLE
fix up some references to 98.css which should refer to XP.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
 
     <p>
       <strong>This library does not contain any JavaScript</strong>, it merely styles your HTML with some CSS.
-      This means 98.css is compatible with your frontend framework of choice.
+      This means XP.css is compatible with your frontend framework of choice.
     </p>
 
     <p>
@@ -796,7 +796,7 @@ import "xp.css/dist/98.css";</pre>
     <h3 id="window">Window</h3>
     <p>
       The following components illustrate how to build complete windows using
-      98.css.
+      XP.css.
     </p>
 
     <section class="component">


### PR DESCRIPTION
Hi,

Thanks for this great project - when I first came across the 98.css project, I spent some time looking around for CSS to theme a web page to look like Windows XP as I liked the idea. But I didn't really find anything and was disappointed - I remember trying to manually draw XP style buttons and other UI elements in Visual Basic 6 back in the day, and have fond memories of it, so I was very excited to see that you've done a wonderful and accurate job here! :)

I noticed on the GH-Pages site, that there were a few references to "98.css" which (I believe - please forgive & correct me if I'm wrong) should really be referring to this project instead for easier clarity, so I am submitting this small patch to fix them.
