### PR TITLE
update link to 98.css image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A design system for building faithful recreations of old UIs.
 
 <img alt="a screenshot of a window with the title 'My First Program' and two buttons OK and Cancel, styled like a Windows XP dialog" src="https://github.com/botoxparty/XP.css/blob/master/docs/window.png?raw=true" height="133">
 
-<img alt="a screenshot of a window with the title 'My First Program' and two buttons OK and Cancel, styled like a Windows 98 dialog" src="https://github.com/jdan/98.css/blob/master/docs/window.png?raw=true" height="133">
+<img alt="a screenshot of a window with the title 'My First Program' and two buttons OK and Cancel, styled like a Windows 98 dialog" src="https://github.com/jdan/98.css/blob/main/docs/window.png?raw=true" height="133">
 
 XP.css is an extension of 98.css. A CSS file that takes semantic HTML and makes it look pretty. It does not ship with any JavaScript, so it is compatible with your frontend framework of choice.
 


### PR DESCRIPTION
hey!

I changed 98.css to use main as its main branch (and encourage you to do the same, [it's very easy](https://twitter.com/jdan/status/1271473612223111168))

this changeset upsets the image URL in your readme