### PR TITLE
Fix GroupBox border for Firefox

### DIFF
--- a/gui/_groupbox.scss
+++ b/gui/_groupbox.scss
@@ -3,8 +3,7 @@
 \*-------------------------------------------*/
 
 fieldset {
-    border: none;
-    box-shadow: var(--border-sunken-outer), var(--border-raised-inner);
+    border-image: svg-load("./icon/groupbox-border.svg") 2;
     padding: calc(2 * var(--border-width) + var(--element-spacing));
     padding-block-start: var(--element-spacing);
     margin: 0;

--- a/gui/icon/groupbox-border.svg
+++ b/gui/icon/groupbox-border.svg
@@ -1,0 +1,4 @@
+<svg width="5" height="5" viewBox="0 0 5 5" fill="grey" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 0H5V5H0V2H2V3H3V2H0" fill="white" />
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 0H4V4H0V1H1V3H3V1H0" fill="#808080" />
+</svg>


### PR DESCRIPTION
This is a similar PR to jdan/98.css#117 which fixes GroupBox rendering for Firefox with the Windows 98 theme.

It also appears to fix an accuracy issue under Chromium.

## Before
![2021-08-06-174725_2289x2111_scrot](https://user-images.githubusercontent.com/5890747/128545190-e196a07c-ae73-4d7a-924d-1330c99fb887.png)

## After:
![2021-08-06-174756_2289x2110_scrot](https://user-images.githubusercontent.com/5890747/128545218-3316117a-8d49-4cfc-91d6-981afb652d84.png)

## Windows 98 reference screenshot:
![image](https://user-images.githubusercontent.com/5890747/128545607-a6fd23ff-31dc-4dc3-b7c3-7cedcfc78182.png)
