### PR TITLE
Button wrapping fix

### DIFF
--- a/gui/_tabs.scss
+++ b/gui/_tabs.scss
@@ -26,7 +26,7 @@ menu[role="tablist"] {
         display: block;
         color: #222;
         text-decoration: none;
-        min-width: unset;
+        min-width: 25px;
         &[aria-selected="true"] {
             padding-bottom: 2px;
             margin-top: -2px;


### PR DESCRIPTION
Before this, buttons would easily fly off of the window, this should fix that.

Tested on my site and it worked perfectly with any value, I just picked 25 since it's nice and divisible and multiplies to other nice divisible numbers.

If this doesn't work for some reason, please let me know and I'll take another look. Thank you!