### PR TITLE
Title bar window should be 28px

### DIFF
--- a/themes/XP/_window.scss
+++ b/themes/XP/_window.scss
@@ -31,7 +31,7 @@
     border-top-right-radius: 7px;
     font-size: 13px;
     text-shadow: 1px 1px #0f1089;
-    height: 21px;
+    height: 28px;
 }
 
 .title-bar-text {


### PR DESCRIPTION
I think the title bar height is off:

before

<img width="411" alt="Screenshot 2025-01-02 at 10 11 20 AM" src="https://github.com/user-attachments/assets/a2b01406-4ef7-4a13-9e1d-3bd7b1dd4fde" />

after

<img width="431" alt="Screenshot 2025-01-02 at 10 10 53 AM" src="https://github.com/user-attachments/assets/0375801b-3b46-4f54-b434-cca5ae78d77e" />
