### PR TITLE
Added windows 98 style progressbar, also make it work with major browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "highlight.js": ">=10.4.1",
     "live-server": "^1.2.1",
     "mkdirp": "^1.0.4",
+    "postcss": "^8.5.4",
     "postcss-calc": "^7.0.2",
     "postcss-copy": "^7.1.0",
     "postcss-css-variables": "^0.14.0",
@@ -44,6 +45,5 @@
     "postcss-inline": "^1.2.0",
     "postcss-inline-svg": "^4.1.0",
     "postcss-nested": "^4.2.1"
-  },
-  "dependencies": {}
+  }
 }

--- a/themes/98/_progressbar.scss
+++ b/themes/98/_progressbar.scss
@@ -1,0 +1,115 @@
+/*-------------------------------------------*\
+    ProgressBar
+\*-------------------------------------------*/
+
+@keyframes sliding {
+  0% {
+    transform: translateX(-40%);
+  }
+  100% {
+    transform: translateX(140%);
+  }
+}
+
+progress {
+  --determinate-track: repeating-linear-gradient(
+    to right,
+    navy 0px,
+    navy 10px,
+    transparent 10px,
+    transparent 12px
+  );
+  --indeterminate-track: repeating-linear-gradient(
+    to right,
+    transparent 0px,
+    transparent 10px,
+    navy 10px,
+    navy 20px,
+    transparent 20px,
+    transparent 22px,
+    navy 22px,
+    navy 32px,
+    transparent 32px,
+    transparent 34px,
+    navy 34px,
+    navy 44px,
+    transparent 44px,
+    transparent 56px,
+    transparent 100%
+  );
+  --indeterminate-track-animation: sliding 2s linear 0s infinite;
+  --track-shadow: inset -2px -2px #dfdfdf, inset 2px 2px grey;
+  --track-height: 24px;
+
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+
+  height: var(--track-height);
+
+  border: 0;
+
+  padding: 4px;
+
+  overflow: hidden;
+  background-color: #c0c0c0;
+
+  box-sizing: border-box;
+  box-shadow: var(--track-shadow);
+
+  &:not(:indeterminate) {
+    &::-webkit-progress-value {
+      background: var(--determinate-track);
+    }
+
+    &::-moz-progress-bar {
+      background: var(--determinate-track);
+    }
+  }
+
+  /* Indeterminate styles */
+  &:indeterminate {
+    position: relative;
+    will-change: left, right;
+
+    /* This pseudo element is to hide the not working -webkit-progress-bar animation above for Chrome and Edge */
+    &::before {
+      content: "";
+      position: absolute;
+
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+
+      z-index: 1;
+
+      box-sizing: border-box;
+      box-shadow: var(--track-shadow);
+    }
+
+    /* Real animated element */
+    &::after {
+      content: "";
+      position: absolute;
+
+      width: 100%;
+      top: 4px;
+      bottom: 4px;
+
+      background: var(--indeterminate-track);
+      animation: var(--indeterminate-track-animation);
+    }
+
+    /* Uses ::after instead */
+    &::-webkit-progress-bar {
+      background-color: transparent;
+    }
+
+    /* Firefox */
+    &::-moz-progress-bar {
+      background: var(--indeterminate-track);
+      animation: var(--indeterminate-track-animation);
+    }
+  }
+}

--- a/themes/98/_progressbar.scss
+++ b/themes/98/_progressbar.scss
@@ -93,9 +93,10 @@ progress {
       content: "";
       position: absolute;
 
-      width: 100%;
+      /* This thing mimic the padding in <progress>, I fear thats not 1:1, but it looks the same I guess */
       top: 4px;
       bottom: 4px;
+      width: 100%;
 
       background: var(--indeterminate-track);
       animation: var(--indeterminate-track-animation);

--- a/themes/98/index.scss
+++ b/themes/98/index.scss
@@ -13,3 +13,4 @@
 @import "_tabs.scss";
 @import "_buttons.scss";
 @import "_treeview.scss";
+@import "_progressbar.scss";

--- a/themes/XP/_progressbar.scss
+++ b/themes/XP/_progressbar.scss
@@ -3,159 +3,158 @@
 \*-------------------------------------------*/
 
 @keyframes sliding {
-    0% {
-      transform: translateX(-30px);
+  0% {
+    transform: translateX(-30px);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+  
+progress {
+  &,
+  &[value],
+  &:not([value]) {
+    --determinate-track: repeating-linear-gradient(
+        to right,
+        #fff 0px,
+        #fff 2px,
+        transparent 2px,
+        transparent 10px
+      ),
+      linear-gradient(
+        to bottom,
+        #acedad 0%,
+        #7be47d 14%,
+        #4cda50 28%,
+        #2ed330 42%,
+        #42d845 57%,
+        #76e275 71%,
+        #8fe791 85%,
+        #ffffff 100%
+      );
+    --indeterminate-track: repeating-linear-gradient(
+        to right,
+        transparent 0px,
+        transparent 8px,
+        #fff 8px,
+        #fff 10px,
+        transparent 10px,
+        transparent 18px,
+        #fff 18px,
+        #fff 20px,
+        transparent 20px,
+        transparent 28px,
+        #fff 28px,
+        #fff 100%
+      ),
+      linear-gradient(
+        to bottom,
+        #acedad 0%,
+        #7be47d 14%,
+        #4cda50 28%,
+        #2ed330 42%,
+        #42d845 57%,
+        #76e275 71%,
+        #8fe791 85%,
+        #ffffff 100%
+      );
+    --indeterminate-track-animation: sliding 2s linear 0s infinite;
+    --track-shadow: inset 0px 0px 1px 0px rgba(104, 104, 104, 1);
+    --track-height: 14px;
+  }
+
+  box-sizing: border-box;
+
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+
+  height: var(--track-height);
+
+  border: 1px solid #686868;
+  border-radius: 4px;
+
+  padding: 1px 2px 1px 0px;
+
+  overflow: hidden;
+  background-color: #fff;
+
+  -webkit-box-shadow: var(--track-shadow);
+  -moz-box-shadow: var(--track-shadow);
+  box-shadow: var(--track-shadow);
+
+  /* Determinate styles */
+  &[value] {
+    /* Chrome, Safari, Edge */
+    &::-webkit-progress-bar {
+      background-color: transparent;
     }
-    100% {
-      transform: translateX(100%);
+    &::-webkit-progress-value {
+      border-radius: 2px;
+      background: var(--determinate-track);
+    }
+    /* Firefox */
+    &::-moz-progress-bar {
+      border-radius: 2px;
+      background: var(--determinate-track);
     }
   }
-  
-  progress {
-    &,
-    &[value],
-    &:not([value]) {
-      --determinate-track: repeating-linear-gradient(
-          to right,
-          #fff 0px,
-          #fff 2px,
-          transparent 2px,
-          transparent 10px
-        ),
-        linear-gradient(
-          to bottom,
-          #acedad 0%,
-          #7be47d 14%,
-          #4cda50 28%,
-          #2ed330 42%,
-          #42d845 57%,
-          #76e275 71%,
-          #8fe791 85%,
-          #ffffff 100%
-        );
-      --indeterminate-track: repeating-linear-gradient(
-          to right,
-          transparent 0px,
-          transparent 8px,
-          #fff 8px,
-          #fff 10px,
-          transparent 10px,
-          transparent 18px,
-          #fff 18px,
-          #fff 20px,
-          transparent 20px,
-          transparent 28px,
-          #fff 28px,
-          #fff 100%
-        ),
-        linear-gradient(
-          to bottom,
-          #acedad 0%,
-          #7be47d 14%,
-          #4cda50 28%,
-          #2ed330 42%,
-          #42d845 57%,
-          #76e275 71%,
-          #8fe791 85%,
-          #ffffff 100%
-        );
-      --indeterminate-track-animation: sliding 2s linear 0s infinite;
-      --track-shadow: inset 0px 0px 1px 0px rgba(104, 104, 104, 1);
-      --track-height: 14px;
+
+  /* Indeterminate styles */
+  &:not([value]) {
+    /* Apply for Chrome, Safari and Edge but animation only works in Safari */
+    &::-webkit-progress-bar {
+      width: 100%;
+      background: var(--indeterminate-track);
+      animation: var(--indeterminate-track-animation);
     }
-  
-    box-sizing: border-box;
-  
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-  
-    height: var(--track-height);
-  
-    border: 1px solid #686868;
-    border-radius: 4px;
-  
-    padding: 1px 2px 1px 0px;
-  
-    overflow: hidden;
-    background-color: #fff;
-  
-    -webkit-box-shadow: var(--track-shadow);
-    -moz-box-shadow: var(--track-shadow);
-    box-shadow: var(--track-shadow);
-  
-    /* Determinate styles */
-    &[value] {
-      /* Chrome, Safari, Edge */
-      &::-webkit-progress-bar {
-        background-color: transparent;
-      }
-      &::-webkit-progress-value {
-        border-radius: 2px;
-        background: var(--determinate-track);
-      }
-      /* Firefox */
-      &::-moz-progress-bar {
-        border-radius: 2px;
-        background: var(--determinate-track);
-      }
+
+    /* Solution for Chrome and Edge: animate pseudo element :after */
+    & {
+      position: relative;
     }
-  
-    /* Indeterminate styles */
-    &:not([value]) {
-      /* Apply for Chrome, Safari and Edge but animation only works in Safari */
-      &::-webkit-progress-bar {
-        width: 100%;
-        background: var(--indeterminate-track);
-        animation: var(--indeterminate-track-animation);
-      }
-  
-      /* Solution for Chrome and Edge: animate pseudo element :after */
-      & {
-        position: relative;
-      }
-      /* This pseudo element is to hide the not working -webkit-progress-bar animation above for Chrome and Edge */
-      &::before {
-        box-sizing: border-box;
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-  
-        width: 100%;
-        height: 100%;
-  
-        background-color: #fff;
-  
-        -webkit-box-shadow: var(--track-shadow);
-        -moz-box-shadow: var(--track-shadow);
-        box-shadow: var(--track-shadow);
-      }
-      /* Real animated element */
-      &::after {
-        box-sizing: border-box;
-        content: "";
-        position: absolute;
-        top: 1px;
-        left: 2px;
-  
-        width: 100%;
-        height: calc(100% - 2px);
-  
-        padding: 1px 2px 1px 2px;
-  
-        border-radius: 2px;
-  
-        background: var(--indeterminate-track);
-        animation: var(--indeterminate-track-animation);
-      }
-  
-      /* Firefox */
-      &::-moz-progress-bar {
-        width: 100%;
-        background: var(--indeterminate-track);
-        animation: var(--indeterminate-track-animation);
-      }
+    /* This pseudo element is to hide the not working -webkit-progress-bar animation above for Chrome and Edge */
+    &::before {
+      box-sizing: border-box;
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+
+      width: 100%;
+      height: 100%;
+
+      background-color: #fff;
+
+      -webkit-box-shadow: var(--track-shadow);
+      -moz-box-shadow: var(--track-shadow);
+      box-shadow: var(--track-shadow);
+    }
+    /* Real animated element */
+    &::after {
+      box-sizing: border-box;
+      content: "";
+      position: absolute;
+      top: 1px;
+      left: 2px;
+
+      width: 100%;
+      height: calc(100% - 2px);
+
+      padding: 1px 2px 1px 2px;
+
+      border-radius: 2px;
+
+      background: var(--indeterminate-track);
+      animation: var(--indeterminate-track-animation);
+    }
+
+    /* Firefox */
+    &::-moz-progress-bar {
+      width: 100%;
+      background: var(--indeterminate-track);
+      animation: var(--indeterminate-track-animation);
     }
   }
-  
+}

--- a/themes/XP/_progressbar.scss
+++ b/themes/XP/_progressbar.scss
@@ -100,6 +100,13 @@ progress {
       content: "";
       position: absolute;
 
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+
+      z-index: 1;
+
       box-sizing: border-box;
       box-shadow: var(--track-shadow);
     }
@@ -108,6 +115,13 @@ progress {
     &::after {
       content: "";
       position: absolute;
+
+      /* This thing mimic the padding in <progress>, I fear thats not 1:1, but it looks the same I guess */
+      top: 1px;
+      bottom: 1px;
+      left: 2px;
+      right: 2px;
+      width: 100%;
 
       background: var(--indeterminate-track);
       animation: var(--indeterminate-track-animation);

--- a/themes/XP/_progressbar.scss
+++ b/themes/XP/_progressbar.scss
@@ -4,67 +4,61 @@
 
 @keyframes sliding {
   0% {
-    transform: translateX(-30px);
+    transform: translateX(-40%);
   }
   100% {
-    transform: translateX(100%);
+    transform: translateX(140%);
   }
 }
-  
-progress {
-  &,
-  &[value],
-  &:not([value]) {
-    --determinate-track: repeating-linear-gradient(
-        to right,
-        #fff 0px,
-        #fff 2px,
-        transparent 2px,
-        transparent 10px
-      ),
-      linear-gradient(
-        to bottom,
-        #acedad 0%,
-        #7be47d 14%,
-        #4cda50 28%,
-        #2ed330 42%,
-        #42d845 57%,
-        #76e275 71%,
-        #8fe791 85%,
-        #ffffff 100%
-      );
-    --indeterminate-track: repeating-linear-gradient(
-        to right,
-        transparent 0px,
-        transparent 8px,
-        #fff 8px,
-        #fff 10px,
-        transparent 10px,
-        transparent 18px,
-        #fff 18px,
-        #fff 20px,
-        transparent 20px,
-        transparent 28px,
-        #fff 28px,
-        #fff 100%
-      ),
-      linear-gradient(
-        to bottom,
-        #acedad 0%,
-        #7be47d 14%,
-        #4cda50 28%,
-        #2ed330 42%,
-        #42d845 57%,
-        #76e275 71%,
-        #8fe791 85%,
-        #ffffff 100%
-      );
-    --indeterminate-track-animation: sliding 2s linear 0s infinite;
-    --track-shadow: inset 0px 0px 1px 0px rgba(104, 104, 104, 1);
-    --track-height: 14px;
-  }
 
-  box-sizing: border-box;
+progress {
+  --determinate-track: repeating-linear-gradient(
+      to right,
+      #fff 0px,
+      #fff 2px,
+      transparent 2px,
+      transparent 10px
+    ),
+    linear-gradient(
+      to bottom,
+      #acedad 0%,
+      #7be47d 14%,
+      #4cda50 28%,
+      #2ed330 42%,
+      #42d845 57%,
+      #76e275 71%,
+      #8fe791 85%,
+      #ffffff 100%
+    );
+  --indeterminate-track: repeating-linear-gradient(
+      to right,
+      transparent 0px,
+      transparent 8px,
+      #fff 8px,
+      #fff 10px,
+      transparent 10px,
+      transparent 18px,
+      #fff 18px,
+      #fff 20px,
+      transparent 20px,
+      transparent 28px,
+      #fff 28px,
+      #fff 100%
+    ),
+    linear-gradient(
+      to bottom,
+      #acedad 0%,
+      #7be47d 14%,
+      #4cda50 28%,
+      #2ed330 42%,
+      #42d845 57%,
+      #76e275 71%,
+      #8fe791 85%,
+      #ffffff 100%
+    );
+  --indeterminate-track-animation: sliding 2s linear 0s infinite;
+  --track-shadow: inset 0px 0px 1px 0px rgba(104, 104, 104, 1);
+  --track-height: 14px;
 
   appearance: none;
   -webkit-appearance: none;
@@ -80,79 +74,52 @@ progress {
   overflow: hidden;
   background-color: #fff;
 
-  -webkit-box-shadow: var(--track-shadow);
-  -moz-box-shadow: var(--track-shadow);
+  box-sizing: border-box;
   box-shadow: var(--track-shadow);
 
   /* Determinate styles */
-  &[value] {
+  &:not(:indeterminate) {
     /* Chrome, Safari, Edge */
-    &::-webkit-progress-bar {
-      background-color: transparent;
-    }
     &::-webkit-progress-value {
-      border-radius: 2px;
       background: var(--determinate-track);
     }
+
     /* Firefox */
     &::-moz-progress-bar {
-      border-radius: 2px;
       background: var(--determinate-track);
     }
   }
 
   /* Indeterminate styles */
-  &:not([value]) {
-    /* Apply for Chrome, Safari and Edge but animation only works in Safari */
-    &::-webkit-progress-bar {
-      width: 100%;
-      background: var(--indeterminate-track);
-      animation: var(--indeterminate-track-animation);
-    }
+  &:indeterminate {
+    position: relative;
+    will-change: left, right;
 
-    /* Solution for Chrome and Edge: animate pseudo element :after */
-    & {
-      position: relative;
-    }
     /* This pseudo element is to hide the not working -webkit-progress-bar animation above for Chrome and Edge */
     &::before {
-      box-sizing: border-box;
       content: "";
       position: absolute;
-      top: 0;
-      left: 0;
 
-      width: 100%;
-      height: 100%;
-
-      background-color: #fff;
-
-      -webkit-box-shadow: var(--track-shadow);
-      -moz-box-shadow: var(--track-shadow);
+      box-sizing: border-box;
       box-shadow: var(--track-shadow);
     }
+
     /* Real animated element */
     &::after {
-      box-sizing: border-box;
       content: "";
       position: absolute;
-      top: 1px;
-      left: 2px;
-
-      width: 100%;
-      height: calc(100% - 2px);
-
-      padding: 1px 2px 1px 2px;
-
-      border-radius: 2px;
 
       background: var(--indeterminate-track);
       animation: var(--indeterminate-track-animation);
+    }
+
+    /* Uses ::after instead */
+    &::-webkit-progress-bar {
+      background-color: transparent;
     }
 
     /* Firefox */
     &::-moz-progress-bar {
-      width: 100%;
       background: var(--indeterminate-track);
       animation: var(--indeterminate-track-animation);
     }


### PR DESCRIPTION
This PR adds the following:

- Windows 98 style progress bar (segmented)
- Fixed animation issues with chrome + edge (also for XP style!)

Known issues:
- box-shadow is too inconsistent for `::before` as it doesn't work well with [scale](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/scale), it seems thats it adds weird transparent lines
- In firefox, `z-index` for the `::before` (our shadow hacky thing), simply get ignored, and the animation overlaps it
- Animation gets faster the more width you add to the `progress` element

I think this is "good to go", but I would appreciate some help fixing these inconsistencies, but I think that's not possible with current CSS state, maybe in the future? Maybe change `progress` element for something else?